### PR TITLE
Fix crash when parsing 3 digit height string

### DIFF
--- a/Sources/DLParser/Parsers/Versions/VersionOneParser.swift
+++ b/Sources/DLParser/Parsers/Versions/VersionOneParser.swift
@@ -76,7 +76,7 @@ final class VersionOneParser: AAMVAParser {
 
         guard
         let feet = feetInches[feetInches.startIndex].string.double,
-        let inches = feetInches[inchesStartIndex...feetInches.endIndex].string.double else {
+        let inches = feetInches[inchesStartIndex..<feetInches.endIndex].string.double else {
             return nil
         }
         return inches + feet * 12


### PR DESCRIPTION
Fix crash (Index out of bounds) when parsing a three digit string from the height field.

#### List of changes this pull request makes

 - Changes the access control of some properties from internal to public


#### Context on why this pull request is being made

Public access modifiers were needed in order to expose the properties of some models from the module.
