### PR TITLE
Fix isJuvenile

### DIFF
--- a/Sources/DLParser/Models/DriverLicense.swift
+++ b/Sources/DLParser/Models/DriverLicense.swift
@@ -227,9 +227,9 @@ extension DriverLicense {
     }
     
     /**
-        Determines if the license holder is 18 or older.
+        Determines if the license holder is a juvenile (under 18).
      
-        Returns: True if the license holder is 18 or older.
+        Returns: True if the license holder is a juvenile (under 18).
      */
     public var isJuvenile: Bool {
         var component = DateComponents()
@@ -240,6 +240,6 @@ extension DriverLicense {
         let calculatedDate = Calendar.current.date(byAdding: component, to: Date()) else {
             return true
         }
-        return calculatedDate >= birthDate
+        return calculatedDate < birthDate
     }
 }


### PR DESCRIPTION
Currently is returning true if the person is an adult, instead of true for when they are a juvenile

#### List of changes this pull request makes

- The property is named `isJuvenile`, so it should return true when the person is under 18

